### PR TITLE
Fix broken link to Package Index File spec in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The purpose of this repository is to store the [Package Index File][a1] for the 
 
 See the following tables for all of the current FreeRTOS CMSIS packs available.
 
-[a1]: https://arm-software.github.io/CMSIS_5/Pack/html/packIndexFile.html
+[a1]: https://open-cmsis-pack.github.io/Open-CMSIS-Pack-Spec/main/html/createPackPublish.html#pidxFile
 
 ## Libraries
 


### PR DESCRIPTION
## Summary
- The README links to the Open-CMSIS-Pack spec page for "Package Index File" but the target URL (via arm-software.github.io redirect) returns 404
- Updated to point directly to the current location of the pidx file specification on open-cmsis-pack.github.io